### PR TITLE
Fix syntax errors and support systems where `sh` isn't bash

### DIFF
--- a/x
+++ b/x
@@ -30,11 +30,10 @@ for SEARCH_PYTHON in py python3 python python2; do
     fi
 done
 
-for SEARCH_PYTHON in (compgen -c "python"  | grep '^python[2-3]\.[0-9]+$); do
-    if python=$(command -v $SEARCH_PYTHON) && [ -x "$python" ]; then
-        exec "$python" "$xpy" "$@"
-    fi
-done
+python=$(bash -c "compgen -c python" | grep '^python[2-3]\.[0-9]\+$' | head -n1)
+if ! [ "$python" = "" ]; then
+    exec "$python" "$xpy" "$@"
+fi
 
 echo "$0: error: did not find python installed" >&2
 exit 1

--- a/x.ps1
+++ b/x.ps1
@@ -29,7 +29,7 @@ foreach ($python in "py", "python3", "python", "python2") {
 }
 
 $found = (Get-Application "python*" | Where-Object {$_.name -match '^python[2-3]\.[0-9]+(\.exe)?$'})
-if (($found -ne $null) -and ($found.Length -ge 1)) {
+if (($null -ne $found) -and ($found.Length -ge 1)) {
     $python = $found[0]
     $process = Start-Process -NoNewWindow -Wait -PassThru $python $xpy_args
     Exit $process.ExitCode


### PR DESCRIPTION
This also switches the order of the condition for the powershell check; according to https://learn.microsoft.com/en-us/powershell/scripting/learn/deep-dives/everything-about-null?view=powershell-7.2#checking-for-null that's more reliable.